### PR TITLE
also destroy the controller plan when starting over

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,10 +374,11 @@ Destroy the Terraform Plans in reverse order if you plan on re-using the directo
 You can tear down the cluster like this.
 
 ```bash
-(cd ./plan-40-client/; terraform destroy;)
-(cd ./plan-30-services/; terraform destroy;)
-(cd ./plan-20-router/; terraform destroy;)
-(cd ./plan-10-k8s/; terraform destroy;)
+(cd ./plan-40-client/;     terraform destroy;)
+(cd ./plan-30-services/;   terraform destroy;)
+(cd ./plan-20-router/;     terraform destroy;)
+(cd ./plan-15-controller/; terraform destroy;)
+(cd ./plan-10-k8s/;        terraform destroy;)
 ```
 
 In your Tunneler, i.e. Desktop Edge, remember to forget your identity. The OpenZiti Identity named "edge-client" in your Tunneler, that is.

--- a/plan-15-controller/terraform.tfvars
+++ b/plan-15-controller/terraform.tfvars
@@ -1,4 +1,0 @@
-# uncomment these two when you're sure you're getting a Let's Encrypt (STAGING) cert in the expected places
-#  this protects you from the hard rate limit enforced by the Let's Encrypt production issuer
-# cluster_issuer_name = "cert-manager-production"
-# cluster_issuer_server = "https://acme-v02.api.letsencrypt.org/directory"


### PR DESCRIPTION
the tfvars file was left over from splitting the root modules and wasn't applicable to the controller plan